### PR TITLE
Bump dependencies to fix vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "icheck": "=1.0.2",
     "immutable": "=3.8.1",
     "malarkey": "=1.3.3",
-    "moment": "=2.18.1",
+    "moment": "^2.23.0",
     "nprogress": "=0.2.0",
     "octicons": "=4.4.0",
     "prop-types": "=15.5.10",
@@ -99,7 +99,7 @@
     "babel-preset-stage-0": "=6.24.1",
     "babelify": "=7.3.0",
     "browserify": "=14.4.0",
-    "electron": "=1.6.10",
+    "electron": "^4.0.1",
     "electron-packager": "=8.7.0",
     "enzyme": "=2.8.2",
     "eslint": "=3.19.0",
@@ -113,7 +113,7 @@
     "react-test-renderer": "=15.5.4",
     "redux-logger": "=3.0.6",
     "redux-mock-store": "=1.2.3",
-    "sass-lint": "=1.10.2 -v",
+    "sass-lint": "=1.10.2",
     "uglify-js": "=3.0.12",
     "watchify": "=3.9.0"
   }


### PR DESCRIPTION
`npm audit` returns several vulnerabilities; fix these by using newer
versions of dependencies.